### PR TITLE
feat: 01 props の基本（親→子へデータを渡す）

### DIFF
--- a/01_quick-start/props-example.jsx
+++ b/01_quick-start/props-example.jsx
@@ -1,0 +1,21 @@
+// 子コンポーネント：受け取った name を表示
+function Greeting({ name = "ゲスト", mood }) {
+  return (
+    <p>
+      こんにちは、{name}さん。今日の気分は {mood ?? "ふつう"} ですね。
+    </p>
+  );
+}
+
+// 親コンポーネント：子にデータ（props）を渡す
+export default function PropsExample() {
+  const userName = "さおり";
+  const todayMood = "ドキドキ！";
+  return (
+    <div>
+      <h2>Props Example</h2>
+      <Greeting name={userName} mood={todayMood} />
+      <Greeting mood="ねむい" /> {/* name を渡さないとデフォルト「ゲスト」 */}
+    </div>
+  );
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,12 @@
 // import Example from "../01_quick-start/example.jsx";
-import Exercise from "../01_quick-start/exercise.jsx";
+// import Exercise from "../01_quick-start/exercise.jsx";
+import PropsExample from "../01_quick-start/props-example.jsx";
 
 export default function App() {
   return (
     <div style={{ padding: 24 }}>
       <h1>learning-React</h1>
-      <Exercise />
+      <PropsExample />
     </div>
   );
 }


### PR DESCRIPTION
## 概要
- 親コンポーネントから子コンポーネントへデータを渡す基本を追加。

## 変更点
- `01_quick-start/props-example.jsx` を追加
- `src/App.jsx` で PropsExample を一時的に表示

## 確認方法
1. `pnpm run dev`
2. http://localhost:5173 を開く
3. 「さおり」「ゲスト」向け2つの挨拶が表示されること
